### PR TITLE
Generalized u_left, u_mid, u_right to an arbitrary number of "markers"

### DIFF
--- a/markers.dat
+++ b/markers.dat
@@ -1,0 +1,7 @@
+p1 0.0075 0.005 0.005
+p2 0.015  0.005 0.005
+p3 0.0225 0.005 0.005
+mid_section_top    0.015 0.005 0.01
+mid_section_bottom 0.015 0.005 0.00
+mid_section_left   0.015 0.00 0.005
+mid_section_right  0.015 0.01 0.005

--- a/parameters.prm
+++ b/parameters.prm
@@ -147,18 +147,5 @@ subsection Measuring locations
     # the solver returns the error: "The evaluation point ... was not 
     # found among the vertices of the present grid."
 
-    # Left point coordinates [m]
-    set Left X = 0.0075
-    set Left Y = 0.005
-    set Left Z = 0.005
-    
-    # Middle point coordinates [m]
-    set Mid X  = 0.015
-    set Mid Y  = 0.005
-    set Mid Z  = 0.005
-
-    # Right point coordinates [m]
-    set Right X = 0.0225
-    set Right Y = 0.005
-    set Right Z = 0.005
+    set Markers list file = markers.dat
 end


### PR DESCRIPTION
* Implemented the `Marker<dim>` class, a generalization of the `Point<dim>` class meant to implement `u_left`, `u_mid`, `u_right` displacement-tracking points and the four points in the mid cross section used to compute bulging.
* `subsection Measurement locations` in `parameters.prm` now only stores the file's name containing the markers (i.e., `markers.dat`).
* Removed `output_bulging_info` since this function only works for the cuboidal geometry. As an alternative, we are now outputting the displacement at these four points in the `displacements-3d.csv` file so that bulging can be computed elsewhere.