### PR TITLE
Minor updates, addressed a warning from deal.II 9.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,7 @@ commit_text.txt
 commit_text.md
 .vscode/
 results/
-2024*/
-2025*/
+2026*/
 *.zip
 
 # Latex

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ SET(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.1.0)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.13.4)
 
 FIND_PACKAGE(deal.II 9.3.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/README.md
+++ b/README.md
@@ -118,23 +118,22 @@ fclose(fid);
 ## Latest line count (in main branch)
 
 ```
-Tue 01 Apr 2025 01:15:09 PM PDT
+Thu 29 Jan 2026 17:05:31 PST 2026
 
->> cloc --exclude-dir=.vscode --exclude-lang=JSON,XML,make .
-    
-    10 text files.
-    10 unique files.                              
-    8 files ignored.
+>> cloc --exclude-dir=.vscode --exclude-lang=JSON,XML,make,YAML,TypeScript,Text,C .
+      89 text files.
+      41 unique files.                              
+      73 files ignored.
 
-github.com/AlDanial/cloc v 1.90  T=0.02 s (182.4 files/s, 333657.2 lines/s)
+github.com/AlDanial/cloc v 2.08  T=0.04 s (546.7 files/s, 167486.9 lines/s)
 -------------------------------------------------------------------------------
 Language                     files          blank        comment           code
 -------------------------------------------------------------------------------
-C++                              1            738           1152           3419
+C++                              3            895           1215           4149
+CMake                           19             86             88            473
 Markdown                         1             35              0            105
-CMake                            1              6             15             18
 -------------------------------------------------------------------------------
-SUM:                             3            779           1167           3542
+SUM:                            23           1016           1303           4727
 -------------------------------------------------------------------------------
 
 ```

--- a/dynamic-muscle.cc
+++ b/dynamic-muscle.cc
@@ -358,7 +358,7 @@ namespace Flexodeal
     {
       std::string type_lin;
       double      tol_lin;
-      double      max_iterations_lin;
+      int         max_iterations_lin;
       bool        use_static_condensation;
       std::string preconditioner_type;
       double      preconditioner_relaxation;
@@ -412,7 +412,7 @@ namespace Flexodeal
       {
         type_lin                  = prm.get("Solver type");
         tol_lin                   = prm.get_double("Residual");
-        max_iterations_lin        = prm.get_double("Max iteration multiplier");
+        max_iterations_lin        = prm.get_integer("Max iteration multiplier");
         use_static_condensation   = prm.get_bool("Use static condensation");
         preconditioner_type       = prm.get("Preconditioner type");
         preconditioner_relaxation = prm.get_double("Preconditioner relaxation");


### PR DESCRIPTION
- Upgraded CMake minimum version required is now 3.13.4 (aligned with deal.II 9.7 basic CMakeLists.txt file).
- Updated README.md
- Fixed `max_iterations_lin` defined as `double` as opposed to `int`. Updated parameters getter accordingly.