### PR TITLE
Convert velocity and orientation fields to vector outputs in VTU files + bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ commit_text.md
 results/
 2026*/
 *.zip
+*.DS_Store
 
 # Latex
 *.aux

--- a/flexodeal-lite.cc
+++ b/flexodeal-lite.cc
@@ -2116,14 +2116,14 @@ namespace Flexodeal
         solve_nonlinear_timestep(solution_delta);
         solution_n += solution_delta;
 
-        // ...and output the results (including VTU files) before moving on 
-        // happily to the next time step:
-        output_results();
-
         // If our computation is dynamic (rather than quasi-static),
         // then we have to update the "previous" variables. 
         if (parameters.type_of_simulation == "dynamic")
             update_timestep();
+
+        // Output the results (including VTU files) before moving on 
+        // happily to the next time step.
+        output_results();
 
         time.increment();
       }
@@ -4223,7 +4223,7 @@ namespace Flexodeal
       return void();
 
     // Create finite element
-    FE_Q<dim> fe_vel(parameters.poly_degree);
+    FE_Q<dim> fe_vel(degree);
     DoFHandler<dim> dof_handler_vel(triangulation);
     dof_handler_vel.distribute_dofs(fe_vel);
 
@@ -4256,12 +4256,54 @@ namespace Flexodeal
         velocity[i]
       );
 
+    // Copy projected components onto a vector field
+    FESystem<dim> fe_vel_vec(FE_Q<dim>(degree), dim);
+    DoFHandler<dim> dof_handler_vel_vec(triangulation);
+    dof_handler_vel_vec.distribute_dofs(fe_vel_vec);
+
+    Vector<double> velocity_vec(dof_handler_vel_vec.n_dofs());
+
+    std::vector<types::global_dof_index> dofs_scalar(fe_vel.dofs_per_cell);
+    std::vector<types::global_dof_index> dofs_vector(fe_vel_vec.dofs_per_cell);
+
+    for (const auto &cell : dof_handler_vel.active_cell_iterators())
+    {
+      const auto cell_vec =
+        typename DoFHandler<dim>::active_cell_iterator(
+          &triangulation,
+          cell->level(),
+          cell->index(),
+          &dof_handler_vel_vec);
+
+      cell->get_dof_indices(dofs_scalar);
+      cell_vec->get_dof_indices(dofs_vector);
+
+      // For FE_Q, local scalar dof index j corresponds to "index within component"
+      for (unsigned int j = 0; j < fe_vel.dofs_per_cell; ++j)
+        for (unsigned int c = 0; c < dim; ++c)
+        {
+          const unsigned int system_index =
+            fe_vel_vec.component_to_system_index(c, j); // (component, index-within-component)
+
+          velocity_vec[dofs_vector[system_index]] =
+            velocity[c][dofs_scalar[j]];
+        }
+    }
+
     // Export to VTK
     DataOut<dim> data_out;
-    data_out.attach_dof_handler(dof_handler_vel);
-    data_out.add_data_vector(velocity[0], "velocity_x");
-    data_out.add_data_vector(velocity[1], "velocity_y");
-    data_out.add_data_vector(velocity[2], "velocity_z");
+    data_out.attach_dof_handler(dof_handler_vel_vec);
+
+    std::vector<std::string> solution_names(dim, "velocity");
+    std::vector<DataComponentInterpretation::DataComponentInterpretation>
+      interpretation(dim,
+        DataComponentInterpretation::component_is_part_of_vector);
+
+    data_out.add_data_vector(
+      velocity_vec,
+      solution_names,
+      DataOut<dim>::type_dof_data,
+      interpretation);
     
     Vector<double> soln(solution_n.size());
     for (unsigned int i = 0; i < soln.size(); ++i)

--- a/flexodeal-lite.cc
+++ b/flexodeal-lite.cc
@@ -4389,13 +4389,63 @@ namespace Flexodeal
       }
     }
 
-    // Store values
+    /* ---------------------------------------------------
+    * Store values: build a multi-component DG output space
+    *   component 0: stretch (scalar)
+    *   components 1..dim: orientation (vector)
+    * --------------------------------------------------- */
+    FESystem<dim> fe_out(FE_DGQ<dim>(degree), 1 + dim);
+    DoFHandler<dim> dof_handler_out(triangulation);
+    dof_handler_out.distribute_dofs(fe_out);
+
+    Vector<double> out(dof_handler_out.n_dofs());
+
+    std::vector<types::global_dof_index> dofs_scalar(fe_stretch.dofs_per_cell);
+    std::vector<types::global_dof_index> dofs_out(fe_out.dofs_per_cell);
+
+    auto cell_scalar = dof_handler_stretch.begin_active();
+    auto cell_out    = dof_handler_out.begin_active();
+    const auto endc  = dof_handler_stretch.end();
+
+    for (; cell_scalar != endc; ++cell_scalar, ++cell_out)
+    {
+      cell_scalar->get_dof_indices(dofs_scalar);
+      cell_out->get_dof_indices(dofs_out);
+
+      for (unsigned int k = 0; k < fe_out.dofs_per_cell; ++k)
+      {
+        const auto comp_and_index = fe_out.system_to_component_index(k);
+        const unsigned int component              = comp_and_index.first;   // 0..dim
+        const unsigned int index_within_component = comp_and_index.second;  // 0..(FE_DGQ dofs_per_cell-1)
+
+        if (component == 0)
+          out[dofs_out[k]] = stretch[dofs_scalar[index_within_component]];
+        else
+        {
+          const unsigned int c = component - 1; // orientation component
+          out[dofs_out[k]] = orientation[c][dofs_scalar[index_within_component]];
+        }
+      }
+    }
+
     DataOut<dim> data_out;
-    data_out.attach_dof_handler(dof_handler_stretch);
-    data_out.add_data_vector(stretch, "stretch");
-    data_out.add_data_vector(orientation[0],"orientation_x");
-    data_out.add_data_vector(orientation[1],"orientation_y");
-    data_out.add_data_vector(orientation[2],"orientation_z");
+    data_out.attach_dof_handler(dof_handler_out);
+
+    std::vector<std::string> names(1 + dim);
+    names[0] = "stretch";
+    for (unsigned int c = 0; c < dim; ++c)
+      names[1 + c] = "orientation";
+
+    std::vector<DataComponentInterpretation::DataComponentInterpretation>
+      interpretation(1 + dim);
+    interpretation[0] = DataComponentInterpretation::component_is_scalar;
+    for (unsigned int c = 0; c < dim; ++c)
+      interpretation[1 + c] = DataComponentInterpretation::component_is_part_of_vector;
+
+    data_out.add_data_vector(out,
+                            names,
+                            DataOut<dim>::type_dof_data,
+                            interpretation);
     
     Vector<double> soln(solution_n.size());
     for (unsigned int i = 0; i < soln.size(); ++i)


### PR DESCRIPTION
New features:
- Muscle velocity and fibre orientation fields were output per component in ParaView files. Now, they are immediately viewable as vectors in ParaView. This allows faster computation of glyphs and steamtracer objects. The latter is important to create visualizations of muscle fibres.

Bug fixes:
- Velocity at timestep 0 and 1 was output as zero. This was because we were calling `output_results()` *before* `update_timestep()`. The calling order was updated in the `Solid<dim>::run()` function.